### PR TITLE
Mispell.

### DIFF
--- a/tornado_pyuv/__init__.py
+++ b/tornado_pyuv/__init__.py
@@ -123,7 +123,7 @@ class IOLoop(object):
             return
         self._thread_ident = thread.get_ident()
         self._running = True
-        self._loop.udate_time()
+        self._loop.update_time()
         while self._running:
             # We should use run() here, but we need to have break() for that
             self._loop.run_once()


### PR DESCRIPTION
`update_time()` but not `udate_time()`.
