### PR TITLE
Add support for Tornado 4

### DIFF
--- a/tornado_pyuv/__init__.py
+++ b/tornado_pyuv/__init__.py
@@ -64,6 +64,8 @@ class UVLoop(IOLoop):
         self._loop = None
 
     def add_handler(self, fd, handler, events):
+        if hasattr(self, 'split_fd'):
+            fd, _ = self.split_fd(fd)
         if fd in self._handlers:
             raise IOError("fd %d already registered" % fd)
         poll = pyuv.Poll(self._loop, fd)
@@ -77,6 +79,8 @@ class UVLoop(IOLoop):
         poll.start(poll_events, self._handle_poll_events)
 
     def update_handler(self, fd, events):
+        if hasattr(self, 'split_fd'):
+            fd, _ = self.split_fd(fd)
         poll = self._handlers[fd]
         poll_events = 0
         if events & IOLoop.READ:
@@ -86,6 +90,8 @@ class UVLoop(IOLoop):
         poll.start(poll_events, self._handle_poll_events)
 
     def remove_handler(self, fd):
+        if hasattr(self, 'split_fd'):
+            fd, _ = self.split_fd(fd)
         poll = self._handlers.pop(fd, None)
         if poll is not None:
             poll.close()


### PR DESCRIPTION
I haven't run the Tornado test suite against this change but it works with a simple web server implementation. This should be the only compatibility change that matters for Tornado 4.0 (see http://www.tornadoweb.org/en/stable/releases/v4.0.0.html#backwards-compatibility-notes).
