### PR TITLE
Configure loop instance

### DIFF
--- a/tornado_pyuv/__init__.py
+++ b/tornado_pyuv/__init__.py
@@ -34,8 +34,8 @@ class Waker(object):
 
 class UVLoop(IOLoop):
 
-    def initialize(self):
-        self._loop = pyuv.Loop()
+    def initialize(self, loop=None):
+        self._loop = loop or pyuv.Loop()
         self._handlers = {}
         self._callbacks = []
         self._callback_lock = thread.allocate_lock()


### PR DESCRIPTION
This allows easier sharing of the pyuv loop instance between multiple implementations. Usage:

```
uv_loop = pyuv.Loop()
ioloop.IOLoop.configure(UVLoop, loop=uv_loop)
```
